### PR TITLE
Fix out of the bounds

### DIFF
--- a/window.c
+++ b/window.c
@@ -62,7 +62,7 @@ SDL_Window *zval_to_sdl_window(zval *z_val)
 static inline void sdl_window_add_long_property(HashTable *props, const char *name, zend_long value)
 {
 	zval zvalue;
-    zend_string *zname = zend_string_init(ZEND_STRS(name), 0);
+    zend_string *zname = zend_string_init(name, strlen(name), 0);
 	ZVAL_LONG(&zvalue, value);
 	zend_hash_update(props, zname, &zvalue);
 	zend_string_release(zname);


### PR DESCRIPTION
When building with security enhancement options and recent GCC

```
libtool: compile:  cc -I/opt/remi/php74/root/usr/include/php -I/opt/remi/php74/root/usr/include/php/main -I/opt/remi/php74/root/usr/include/php/TSRM -I/opt/remi/php74/root/usr/include/php/Zend -I/opt/remi/php74/root/usr/include/php/ext -I/opt/remi/php74/root/usr/include/php/ext/date/lib -DHAVE_SDL2 -Wall -Wfatal-errors -I. -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS -DPHP_ATOM_INC -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/include -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/main -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS -I/opt/remi/php74/root/usr/include/php -I/opt/remi/php74/root/usr/include/php/main -I/opt/remi/php74/root/usr/include/php/TSRM -I/opt/remi/php74/root/usr/include/php/Zend -I/opt/remi/php74/root/usr/include/php/ext -I/opt/remi/php74/root/usr/include/php/ext/date/lib -I/usr/include/SDL2 -DHAVE_CONFIG_H -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -c /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/video.c  -fPIC -DPIC -o .libs/video.o
libtool: compile:  cc -I/opt/remi/php74/root/usr/include/php -I/opt/remi/php74/root/usr/include/php/main -I/opt/remi/php74/root/usr/include/php/TSRM -I/opt/remi/php74/root/usr/include/php/Zend -I/opt/remi/php74/root/usr/include/php/ext -I/opt/remi/php74/root/usr/include/php/ext/date/lib -DHAVE_SDL2 -Wall -Wfatal-errors -I. -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS -DPHP_ATOM_INC -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/include -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/main -I/dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS -I/opt/remi/php74/root/usr/include/php -I/opt/remi/php74/root/usr/include/php/main -I/opt/remi/php74/root/usr/include/php/TSRM -I/opt/remi/php74/root/usr/include/php/Zend -I/opt/remi/php74/root/usr/include/php/ext -I/opt/remi/php74/root/usr/include/php/ext/date/lib -I/usr/include/SDL2 -DHAVE_CONFIG_H -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -c /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c  -fPIC -DPIC -o .libs/window.o
In file included from /usr/include/string.h:494,
                 from /opt/remi/php74/root/usr/include/php/main/../main/php_config.h:2344,
                 from /opt/remi/php74/root/usr/include/php/Zend/zend_config.h:1,
                 from /opt/remi/php74/root/usr/include/php/Zend/zend_portability.h:43,
                 from /opt/remi/php74/root/usr/include/php/Zend/zend_types.h:25,
                 from /opt/remi/php74/root/usr/include/php/Zend/zend.h:27,
                 from /opt/remi/php74/root/usr/include/php/main/php.h:33,
                 from /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/php_sdl.h:32,
                 from /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.h:28,
                 from /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:20:
In function 'memcpy',
    inlined from 'zend_string_init' at /opt/remi/php74/root/usr/include/php/Zend/zend_string.h:157:2,
    inlined from 'sdl_window_add_long_property' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:65:26,
    inlined from 'sdl_window_get_properties' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:86:3:
/usr/include/bits/string_fortified.h:34:10: warning: '__builtin_memcpy' forming offset [4, 8] is out of the bounds [0, 3] [-Warray-bounds]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'memcpy',
    inlined from 'zend_string_init' at /opt/remi/php74/root/usr/include/php/Zend/zend_string.h:157:2,
    inlined from 'sdl_window_add_long_property' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:65:26,
    inlined from 'sdl_window_get_properties' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:87:3:
/usr/include/bits/string_fortified.h:34:10: warning: '__builtin_memcpy' forming offset [7, 8] is out of the bounds [0, 6] [-Warray-bounds]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'memcpy',
    inlined from 'zend_string_init' at /opt/remi/php74/root/usr/include/php/Zend/zend_string.h:157:2,
    inlined from 'sdl_window_add_long_property' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:65:26,
    inlined from 'sdl_window_get_properties' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:88:3:
/usr/include/bits/string_fortified.h:34:10: warning: '__builtin_memcpy' forming offset [3, 8] is out of the bounds [0, 2] [-Warray-bounds]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'memcpy',
    inlined from 'zend_string_init' at /opt/remi/php74/root/usr/include/php/Zend/zend_string.h:157:2,
    inlined from 'sdl_window_add_long_property' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:65:26,
    inlined from 'sdl_window_get_properties' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:89:3:
/usr/include/bits/string_fortified.h:34:10: warning: '__builtin_memcpy' forming offset [3, 8] is out of the bounds [0, 2] [-Warray-bounds]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'memcpy',
    inlined from 'zend_string_init' at /opt/remi/php74/root/usr/include/php/Zend/zend_string.h:157:2,
    inlined from 'sdl_window_add_long_property' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:65:26,
    inlined from 'sdl_window_get_properties' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:90:3:
/usr/include/bits/string_fortified.h:34:10: warning: '__builtin_memcpy' forming offset [3, 8] is out of the bounds [0, 2] [-Warray-bounds]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'memcpy',
    inlined from 'zend_string_init' at /opt/remi/php74/root/usr/include/php/Zend/zend_string.h:157:2,
    inlined from 'sdl_window_add_long_property' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:65:26,
    inlined from 'sdl_window_get_properties' at /dev/shm/BUILD/php74-php-pecl-sdl-2.2.2/NTS/window.c:91:3:
/usr/include/bits/string_fortified.h:34:10: warning: '__builtin_memcpy' forming offset [3, 8] is out of the bounds [0, 2] [-Warray-bounds]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```