### PR TITLE
fix: duplicate symbols during link on OsX

### DIFF
--- a/src/pixels.c
+++ b/src/pixels.c
@@ -35,6 +35,7 @@ struct php_sdl_palette {
 	Uint32        flags;
 };
 
+zend_class_entry *php_sdl_pixelformat_ce;
 static zend_object_handlers php_sdl_pixelformat_handlers;
 struct php_sdl_pixelformat {
 	SDL_PixelFormat *format;
@@ -42,6 +43,7 @@ struct php_sdl_pixelformat {
 	zend_object      zo;
 };
 
+zend_class_entry *php_sdl_pixels_ce;
 static zend_object_handlers php_sdl_pixels_handlers;
 struct php_sdl_pixels {
 	zend_object      zo;

--- a/src/pixels.h
+++ b/src/pixels.h
@@ -35,8 +35,8 @@ typedef struct SDL_Pixels
     Uint8 *pixels;
 } SDL_Pixels;
 
-zend_class_entry *php_sdl_pixelformat_ce;
-zend_class_entry *php_sdl_pixels_ce;
+extern zend_class_entry *php_sdl_pixelformat_ce;
+extern zend_class_entry *php_sdl_pixels_ce;
 
 zend_class_entry *get_php_sdl_color_ce(void);
 zend_bool sdl_color_to_zval(SDL_Color *color, zval *value);

--- a/src/rect.c
+++ b/src/rect.c
@@ -19,6 +19,7 @@
 
 #include "rect.h"
 
+zend_class_entry *php_sdl_rect_ce;
 static zend_object_handlers php_sdl_rect_handlers;
 struct php_sdl_rect {
 	zend_object   zo;

--- a/src/rect.h
+++ b/src/rect.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #include "php_sdl.h"
 
-zend_class_entry *php_sdl_rect_ce;
+extern zend_class_entry *php_sdl_rect_ce;
 
 zend_class_entry *get_php_sdl_point_ce(void);
 zend_bool sdl_point_to_zval(SDL_Point *pt, zval *value);


### PR DESCRIPTION
As explained in #37, I face strange link errors on my OsX machine.
After some search, it seems to be related to this commit https://github.com/Ponup/php-sdl/commit/1161d7272c553352a8e14cba15334af47ee44137

It moves _internal_ variables from `.c` files to corresponding `.h` files, to share them with `surface.c`. As far as I remember my C, we have to put an `extern` declaration in header file and to let the concrete definition in `.c` file, exactly to prevent multiple definitions. But I can't figure why it worked correctly on other environments… is it due to a special configuration on my machine?

Furthermore, why the shown  duplicated symbol is `_php_sdl_pixels_ce` since the declared symbol is `php_sdl_pixels_ce` (without `_` prefix)? Is it related to a secret Php macro?

What do you think? 🤔 
Thanks, have a nice day 😄 

fix #37 