### PR TITLE
Rename width parameter in SDL_Rect::__construct()

### DIFF
--- a/src/rect.h
+++ b/src/rect.h
@@ -39,7 +39,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_SDL_Rect__construct, /*unused*/0, /*ret ref*/0, /
        ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
        ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
        ZEND_ARG_TYPE_INFO(0, w, IS_LONG, 0)
-       ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+       ZEND_ARG_TYPE_INFO(0, h, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 


### PR DESCRIPTION
fix "Duplicate parameter name $y for function SDL_Rect::__construct()"