### PR TITLE
Add manually the list of file to compile and add src as build dir

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -55,6 +55,32 @@ if test "$PHP_SDL" != "no"; then
   PHP_SUBST(SDL_SHARED_LIBADD)
   AC_DEFINE(HAVE_SDL2, 1, [ ])
 
-  SDL_SOURCE_FILES="`find src -name "*.c"`"
+  SDL_SOURCE_FILES="src/blendmode.c \
+	src/cpuinfo.c \
+	src/error.c \
+	src/event.c \
+	src/filesystem.c \
+	src/glcontext.c \
+	src/joystick.c \
+	src/keyboard.c \
+	src/messagebox.c \
+	src/mouse.c \
+	src/mutex.c \
+	src/php_sdl.c \
+	src/pixels.c \
+	src/platform.c \
+	src/power.c \
+	src/rect.c \
+	src/render.c \
+	src/rwops.c \
+	src/sdl.c \
+	src/shape.c \
+	src/surface.c \
+	src/timer.c \
+	src/version.c \
+	src/video.c \
+	src/window.c"
+
   PHP_NEW_EXTENSION(sdl, $SDL_SOURCE_FILES, $ext_shared,, $PHP_SDL_CFLAGS)
+  PHP_ADD_BUILD_DIR($ext_builddir/src)
 fi

--- a/package.xml
+++ b/package.xml
@@ -73,6 +73,8 @@
         <file role="src" name="power.h"/>
         <file role="src" name="rect.c"/>
         <file role="src" name="rect.h"/>
+        <file role="src" name="rect.stub.php"/>
+        <file role="src" name="rect_arginfo.h"/>
         <file role="src" name="render.c"/>
         <file role="src" name="render.h"/>
         <file role="src" name="rwops.c"/>


### PR DESCRIPTION
Should fix #58 
I've tried many constant and macro to use with the `find` command but I didn't find a way.
To reproduce, from source dir:
```
pecl package
mkdir -p temp && cd temp
cp ../sdl-2.5.0.tgz .
pecl install sdl-2.5.0.tgz
```
Without this patch
- error on find command
```
...
checking for SDL2 library... using SDL2 version 2.0.20
find: src: No such file or directory
checking for a sed that does not truncate output... /usr/bin/sed
...
```
- one compilation command
- the lib is about 16K

With this patch
- all .c files are compiled
- the lib is about 350K

