### PR TITLE
Remove invalid tests for SDL_Pixels array access

### DIFF
--- a/tests/014-version.phpt
+++ b/tests/014-version.phpt
@@ -26,7 +26,8 @@ var_dump(12030 === SDL_VERSIONNUM(10,20,30));
 var_dump(SDL_VERSION_ATLEAST(2,0,0));
 var_dump(SDL_VERSION_ATLEAST(2,0,25));
 var_dump(is_string(SDL_GetRevision()));
-var_dump(is_integer(SDL_GetRevisionNumber()));
+SDL_GetVersion($linkedVersion);
+var_dump(array_key_exists('major', $linkedVersion) && array_key_exists('minor', $linkedVersion) && array_key_exists('patch', $linkedVersion));
 
 echo '= Done', PHP_EOL;
 ?>

--- a/tests/021-surface-oo.phpt
+++ b/tests/021-surface-oo.phpt
@@ -61,26 +61,14 @@ string(40) "SDL_Surface(%d,150,100,8,0x0,0x0,0x0,0x0)"
 int(150)
 int(100)
 int(256)
-object(SDL_Pixels)#%d (3) {
-  ["pitch"]=>
-  int(152)
-  ["h"]=>
-  int(100)
-  ["count"]=>
-  int(15200)
+object(SDL_Pixels)#%d (0) {
 }
 = Create True colors
 string(57) "SDL_Surface(%d,150,100,32,0xff000000,0xff0000,0xff00,0xff)"
 int(150)
 int(100)
 NULL
-object(SDL_Pixels)#%d (3) {
-  ["pitch"]=>
-  int(600)
-  ["h"]=>
-  int(100)
-  ["count"]=>
-  int(60000)
+object(SDL_Pixels)#%d (0) {
 }
 = Lock
 bool(false)

--- a/tests/022-pixels.phpt
+++ b/tests/022-pixels.phpt
@@ -14,19 +14,6 @@ try {
 	echo "Exception: " . $e->getMessage() . "\n";
 }
 var_dump($pix = new SDL_Pixels(10, 10), "$pix");
-echo "= Get/Set\n";
-var_dump($pix->GetByte(15,15));
-var_dump($pix->SetByte(0,0,1));
-var_dump($pix->GetByte(0,0));
-var_dump($pix->SetByte(1,1,255));
-var_dump($pix->GetByte(1,1));
-
-echo "= Array\n";
-var_dump($pix[20], isset($pix[20]), isset($pix[1000]));
-var_dump($pix[20]=127);
-var_dump($pix[20]);
-unset($pix[20]);
-var_dump($pix[20]);
 ?>
 = Done
 --EXPECTF--
@@ -34,28 +21,7 @@ var_dump($pix[20]);
 Exception: Invalid size
 
 Notice: SDL_Pixels::__construct(): Pitch set to 12 in %s%e022-pixels.php on line 8
-object(SDL_Pixels)#%d (3) {
-  ["pitch"]=>
-  int(12)
-  ["h"]=>
-  int(10)
-  ["count"]=>
-  int(120)
+object(SDL_Pixels)#%d (0) {
 }
-string(17) "SDL_Pixels(12,10)"
-= Get/Set
-
-Notice: SDL_Pixels::GetByte(): Invalid position (15,15) in SDL_Pixels (12,10) in %s%e022-pixels.php on line 10
-bool(false)
-int(0)
-int(1)
-int(0)
-int(255)
-= Array
-int(0)
-bool(true)
-bool(false)
-int(127)
-int(127)
-int(0)
+string(10) "SDL_Pixels"
 = Done


### PR DESCRIPTION
Array access and some properties of SDL_Pixels were removed here
https://github.com/Ponup/php-sdl/commit/3206f3cffc91aafe31e813996f02ec6be1b8d2b3

Use of SDL_GetVersion instead of deprecated SDL_GetRevisionNumber in "version" tests.